### PR TITLE
added __amigaos3__ define to standard set of default defines.

### DIFF
--- a/gcc/config/m68k/amigaos.h
+++ b/gcc/config/m68k/amigaos.h
@@ -114,6 +114,7 @@ Boston, MA 02111-1307, USA.  */
   "-Damigaos "                                                    \
   "-DMCH_AMIGA "                                                  \
   "-DAMIGA "                                                      \
+  "-D__amigaos3__ "                                               \
   "-D__chip=__attribute__((__chip__)) "                           \
   "-D__saveds=__attribute__((__saveds__)) "                       \
   "-D__interrupt=__attribute__((__interrupt__)) "                 \


### PR DESCRIPTION
added __amigaos3__ define to standard set of default defines. This should allow to detect classic Amiga systems (<= AmigaOS3) in multi-platform projects more easily. This refs cahirwpz/amigaos-cross-toolchain#62.